### PR TITLE
Fix date shorthands to use German locale

### DIFF
--- a/frontend/src/utils/moment.js
+++ b/frontend/src/utils/moment.js
@@ -1,5 +1,21 @@
 import moment from "moment";
+
+moment.defineLocale("de", {
+  weekdays: "Sonntag_Montag_Dienstag_Mittwoch_Donnerstag_Freitag_Samstag".split("_"),
+  weekdaysShort: "So._Mo._Di._Mi._Do._Fr._Sa.".split("_"),
+  weekdaysMin: "So_Mo_Di_Mi_Do_Fr_Sa".split("_"),
+  months: "Januar_Februar_März_April_Mai_Juni_Juli_August_September_Oktober_November_Dezember".split("_"),
+  monthsShort: "Jan._Feb._März_Apr._Mai_Juni_Juli_Aug._Sep._Okt._Nov._Dez.".split("_"),
+  longDateFormat: {
+    LT: "HH:mm",
+    LTS: "HH:mm:ss",
+    L: "DD.MM.YYYY",
+    LL: "D. MMMM YYYY",
+    LLL: "D. MMMM YYYY HH:mm",
+    LLLL: "dddd, D. MMMM YYYY HH:mm",
+  },
+});
+
 export const momentInstance = inp => {
-  moment.locale("de");
   return moment(inp);
 };


### PR DESCRIPTION
## Summary

- Fixes calendar weekday abbreviations displaying in English (SU, MO, TU, WE) instead of German (SO, MO, DI, MI)
- Replaces broken `import "moment/locale/de"` side-effect with `moment.defineLocale("de", ...)` called directly at module level
- Root cause: Vite's native ESM context sets `this` to `undefined`, so the UMD locale file's `factory(global.moment)` call silently failed, leaving moment on the English locale

## Test plan

- [x] Sidebar meeting dates show German weekday abbreviations (SO, MO, DI, MI, DO, FR, SA)
- [x] Termine page shows German weekday abbreviations
- [x] Roster view shows German weekday abbreviations
- [x] Month names display in German (Januar, Februar, März, ...)

🤖 Generated with [Claude Code](https://claude.com/claude-code)